### PR TITLE
Remove vestigial cabal file copy from Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /opt/fission-ipfs-api
 # Cache common files #
 ######################
 
-COPY ipfs-api.cabal /opt/fission-ipfs-api
 COPY stack.yaml     /opt/fission-ipfs-api
 
 ##########################


### PR DESCRIPTION
**Summary**

`Dockerfile` contained a vestigial `.cabal` file from the scaffolding. Have since switched to Stack. This was causing issues for containers that didn't have the cache yet.

**Fixes**

* [x] Closes #3

**Notes**

A big thank you to @hharnisc for the report!