### PR TITLE
Track cabal file for Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ dist
 dist-*
 dist-newstyle
 cabal-dev
-*.cabal
 *.o
 *.hi
 *.chi

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /opt/fission-ipfs-api
 # Cache common files #
 ######################
 
+COPY ipfs-api.cabal /opt/fission-ipfs-api
 COPY stack.yaml     /opt/fission-ipfs-api
 
 ##########################

--- a/ipfs-api.cabal
+++ b/ipfs-api.cabal
@@ -1,0 +1,256 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.1.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: fd19d87aa691a86a6bde8e1f9184983249fda0a9910f4046b382f78e437f09e3
+
+name:           ipfs-api
+version:        0.0.1.0
+category:       API
+homepage:       https://github.com/fission-suite/ipfs-api#readme
+bug-reports:    https://github.com/fission-suite/ipfs-api/issues
+author:         Brooklyn Zelenka
+maintainer:     hello@brooklynzelenka.com
+copyright:      © 2019 Brooklyn Zelenka
+license:        Apache-2.0
+license-file:   LICENSE
+tested-with:    GHC==8.6.3
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/fission-suite/ipfs-api
+
+library
+  exposed-modules:
+      Fission
+      Fission.Ambient
+      Fission.Env
+      Fission.Internal.Constraint
+      Fission.Internal.UTF8
+      Fission.IPFS.Peer
+      Fission.Log
+      Fission.Web
+      Fission.Web.IPFS
+      Fission.Web.Ping
+  other-modules:
+      Paths_ipfs_api
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , lens
+    , monad-logger
+    , rio
+    , servant-server
+    , text
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+executable server
+  main-is: Main.hs
+  other-modules:
+      Paths_ipfs_api
+  hs-source-dirs:
+      app
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -threaded -rtsopts -with-rtsopts=-N -O2
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , ipfs-api
+    , lens
+    , monad-logger
+    , rio
+    , servant-server
+    , text
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+test-suite fission-coverage
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_ipfs_api
+  hs-source-dirs:
+      test/coverage
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -fhpc
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , ipfs-api
+    , lens
+    , monad-logger
+    , process
+    , regex-compat
+    , rio
+    , servant-server
+    , text
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+test-suite fission-docs
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_ipfs_api
+  hs-source-dirs:
+      test/docs
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , doctest
+    , ipfs-api
+    , lens
+    , monad-logger
+    , process
+    , regex-compat
+    , rio
+    , servant-server
+    , text
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+test-suite fission-doctest
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_ipfs_api
+  hs-source-dirs:
+      test/doctest
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      Glob
+    , QuickCheck
+    , aeson
+    , base
+    , bytestring
+    , doctest
+    , ipfs-api
+    , lens
+    , monad-logger
+    , rio
+    , servant-server
+    , text
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+test-suite fission-lint
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_ipfs_api
+  hs-source-dirs:
+      test/lint
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , hlint
+    , lens
+    , monad-logger
+    , rio
+    , servant-server
+    , text
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+test-suite fission-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Fission
+      Fission.Ambient
+      Fission.Env
+      Fission.Internal.Constraint
+      Fission.Internal.UTF8
+      Fission.IPFS.Peer
+      Fission.Log
+      Fission.Web
+      Fission.Web.IPFS
+      Fission.Web.Ping
+      Paths_ipfs_api
+  hs-source-dirs:
+      src
+      test
+      test/testsuite
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -fhpc -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , hspec
+    , hspec-wai
+    , hspec-wai-json
+    , ipfs-api
+    , lens
+    , monad-logger
+    , rio
+    , servant-server
+    , tasty
+    , tasty-hspec
+    , tasty-hunit
+    , tasty-rerun
+    , tasty-smallcheck
+    , text
+    , transformers
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+benchmark fission-benchmark
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_ipfs_api
+  hs-source-dirs:
+      benchmark
+  ghc-options: -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -threaded -rtsopts -with-rtsopts=-N -O2
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , criterion
+    , ipfs-api
+    , lens
+    , monad-logger
+    , rio
+    , servant-server
+    , text
+    , typed-process
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -7,7 +7,7 @@ copyright: © 2019 Brooklyn Zelenka
 license: Apache-2.0
 license-file: LICENSE
 github: fission-suite/ipfs-api
-tested-with: GHC==8.6.4
+tested-with: GHC==8.6.3
 extra-source-files:
   - README.md
   - CHANGELOG.md


### PR DESCRIPTION
* Track `ipfs-api.cabal` again (for simplicity with Docker)
* Downgrade the tested version to `8.6.3`, again because Docker is behind
  * Started building totally custom container, but have bigger fish to fry 🎣 