### PR TITLE
Strip quotes from ToSchema Region

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: true
 language: haskell
 ghc:
-  - "8.6.3"
+  - "8.6.5"
 
 git:
   depth: 5

--- a/src/Fission/Platform/Heroku/Types.hs
+++ b/src/Fission/Platform/Heroku/Types.hs
@@ -5,10 +5,10 @@ module Fission.Platform.Heroku.Types
   ) where
 
 import RIO
+import RIO.Partial (read)
 
 import Database.Selda (SqlType)
 import Data.Aeson
-import Data.Aeson.Casing
 import Data.Swagger as Swagger
 
 -- | Heroku add-on ID (from @addon-manifest.json@)
@@ -64,5 +64,10 @@ instance FromJSON Region where
     bad -> fail $ "Invalid region: " <> show bad
 
 instance ToSchema Region where
-  declareNamedSchema = genericDeclareNamedSchema
-    $ defaultSchemaOptions { Swagger.constructorTagModifier = camelCase }
+  declareNamedSchema = genericDeclareNamedSchema $ defaultSchemaOptions
+    { Swagger.constructorTagModifier = (\str -> take (length str - 1) str)
+                                     . drop 8
+                                     . show
+                                     . toJSON
+                                     . (read :: String -> Region)
+    }


### PR DESCRIPTION
Very minor: remove double quotes from string, since Swagger doesn't seem to want them by default (artifact of relying on `ToJSON`)